### PR TITLE
support response buffering

### DIFF
--- a/cmd/autocertproxy/main.go
+++ b/cmd/autocertproxy/main.go
@@ -68,7 +68,7 @@ func main() {
 		)
 	}
 
-	ctx := proxy.RootContext()
+	ctx, _ := proxy.RootContext()
 
 	if err := p.ListenAndServe(ctx); err != nil {
 		os.Exit(1)

--- a/internal/proxy/config/config.go
+++ b/internal/proxy/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	DstHost               string        `json:"DST_HOST" envconfig:"DST_HOST" default:"127.0.0.1"`
 	DstHostHeader         string        `json:"DST_HOST_HEADER" envconfig:"DST_HOST_HEADER" default:""`
 	DstPort               int           `json:"DST_PORT" envconfig:"DST_PORT" default:"8080"`
+	ResponseBufferEnabled bool          `json:"RESPONSE_BUFFER_ENABLED" envconfig:"RESPONSE_BUFFER_ENABLED" default:"false"`
 	AdminEmail            string        `json:"ADMIN_EMAIL" envconfig:"ADMIN_EMAIL" default:""`
 	AutocertCacheDir      string        `json:"AUTOCERT_CACHE_DIR" envconfig:"AUTOCERT_CACHE_DIR" default:"./.autocert"`
 	Authorization         string        `json:"AUTHORIZATION" default:""`


### PR DESCRIPTION
Can now buffer responses server side before rendering them to clients.
Useful if there are slow clients and response bodies are large enough to occupy too many http connections to the proxy origin.